### PR TITLE
Add inheritance of spatial data for functional plugin that return layer data. 

### DIFF
--- a/napari/_qt/_qapp_model/injection/_qprocessors.py
+++ b/napari/_qt/_qapp_model/injection/_qprocessors.py
@@ -69,6 +69,7 @@ def _add_layer_data_to_viewer(
     viewer: viewer.Viewer | None = None,
     layer_name: str | None = None,
     source: dict | None = None,
+    meta: dict | None = None,
 ) -> None:
     """Show a result in the viewer.
 
@@ -79,13 +80,16 @@ def _add_layer_data_to_viewer(
         *just* the data part of the corresponding layer type.
     return_type : Any
         The return annotation that was used in the decorated function.
-    viewer : Optional[Viewer]
+    viewer : Viewer or None
         An optional viewer to use. Otherwise use current viewer.
-    layer_name : Optional[str]
+    layer_name : str or None
         An optional layer name to use. If a layer with this name exists, it will
         be updated.
-    source : Optional[dict]
+    source : dict or None
         An optional layer source to use.
+    meta: dict or None
+        An optional dict pased as keyword arguments to the layer constructor.
+        Currently used to pass information like a scale, units, etc.
 
     Examples
     --------
@@ -95,6 +99,8 @@ def _add_layer_data_to_viewer(
     ...     return np.random.rand(256, 256)
 
     """
+    if meta is None:
+        meta = {}
     if data is not None and (viewer := viewer or _provide_viewer()):
         if layer_name:
             with suppress(KeyError):
@@ -111,8 +117,11 @@ def _add_layer_data_to_viewer(
                 )
             return_type = return_type.__args__[0]
         layer_type = return_type.__name__.replace('Data', '').lower()
+
         with layer_source(**source) if source else nullcontext():
-            getattr(viewer, f'add_{layer_type}')(data=data, name=layer_name)
+            getattr(viewer, f'add_{layer_type}')(
+                data=data, name=layer_name, **meta
+            )
 
 
 def _add_layer_to_viewer(

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -1,15 +1,19 @@
 import contextlib
 import sys
 import time
+from enum import Enum
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 from magicgui import magicgui
 
 from napari import Viewer, layers, types
 from napari._tests.utils import layer_test_data
-from napari.layers import Image, Labels, Layer
+from napari.layers import Image, Labels, Layer, Points, Surface
+from napari.utils._magicgui import _get_ndim_from_data
 from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.migrations import _DeprecatingDict
 from napari.utils.misc import all_subclasses
@@ -27,6 +31,75 @@ except RuntimeError:
     )
 
 
+@pytest.fixture
+def image_layer():
+    return Image(
+        np.empty((40, 40), dtype=np.uint8),
+        scale=(1, 2),
+        translate=(3, 4),
+        units=('nm', 'um'),
+    )
+
+
+@pytest.fixture
+def image_layer3d():
+    return Image(
+        np.empty((10, 40, 40), dtype=np.uint8),
+        scale=(1, 2, 2),
+        translate=(3, 4, 4),
+        units=('nm', 'um', 'um'),
+    )
+
+
+@pytest.fixture
+def image_layer_rgb():
+    return Image(
+        np.empty((40, 40, 3), dtype=np.uint8),
+        scale=(1, 2),
+        translate=(3, 4),
+        units=('nm', 'um'),
+    )
+
+
+@pytest.fixture
+def labels_layer():
+    return Labels(
+        np.empty((40, 40), dtype=np.uint8),
+        scale=(1, 2),
+        translate=(3, 4),
+        units=('nm', 'um'),
+    )
+
+
+@pytest.fixture
+def points_layer():
+    return Points(
+        np.empty((10, 2), dtype=np.uint8).astype(np.float32),
+        scale=(1, 2),
+        translate=(3, 4),
+        units=('nm', 'um'),
+    )
+
+
+@pytest.fixture
+def surface_layer():
+    rng = np.random.default_rng(0)
+    return Surface(
+        (20 * rng.random((10, 3)), rng.integers(10, size=(6, 3))),
+        scale=(1, 2, 2),
+        translate=(3, 4, 4),
+        units=('nm', 'um', 'um'),
+    )
+
+
+@pytest.fixture(
+    params=['image_layer', 'labels_layer', 'points_layer', 'image_layer_rgb']
+)
+def layer_and_type(request):
+    data = request.getfixturevalue(request.param)
+    return data, getattr(types, f'{data.__class__.__name__}Data')
+
+
 # only test the first of each layer type
 test_data = []
 for cls in all_subclasses(Layer):
@@ -34,6 +107,11 @@ for cls in all_subclasses(Layer):
     with contextlib.suppress(StopIteration):
         test_data.append(next(x for x in layer_test_data if x[0] is cls))
 test_data.sort(key=lambda x: x[0].__name__)  # required for xdist to work
+
+
+@pytest.mark.parametrize(('LayerType', 'data', 'ndim'), layer_test_data)
+def test_get_ndim_from_data(LayerType, data, ndim):
+    assert _get_ndim_from_data(data, LayerType.__name__.lower()) == ndim
 
 
 @pytest.mark.parametrize(('LayerType', 'data', 'ndim'), test_data)
@@ -57,6 +135,185 @@ def test_magicgui_add_data(make_napari_viewer, LayerType, data, ndim):
     assert len(viewer.layers) == 1
     assert isinstance(viewer.layers[0], LayerType)
     assert viewer.layers[0].source.widget == add_data
+
+
+def test_magicgui_add_data_inheritance(
+    make_napari_viewer, layer_and_type, image_layer
+):
+    """This test validates if the scale and translate are inherited from the
+    previous layer when adding a new layer with magicgui if function requests,
+    a LayerData type.
+    """
+    layer, type_ = layer_and_type
+    viewer = make_napari_viewer()
+    viewer.add_layer(image_layer)
+
+    @magicgui
+    def add_data(data: types.ImageData) -> type_:
+        return layer.data
+
+    viewer.window.add_dock_widget(add_data)
+    add_data()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[1], layer.__class__)
+    npt.assert_array_equal(viewer.layers[1].scale, (1, 2))
+    npt.assert_array_equal(viewer.layers[1].translate, (3, 4))
+    assert viewer.layers[1].units == viewer.layers[0].units
+
+
+def test_magicgui_add_data_inheritance_surface(
+    make_napari_viewer, surface_layer, image_layer3d
+):
+    """This test validates if the scale and translate are inherited from the
+    previous layer when adding a new layer with magicgui if function requests,
+    a LayerData type.
+    """
+    viewer = make_napari_viewer()
+    viewer.add_layer(image_layer3d)
+
+    @magicgui
+    def add_data(data: types.ImageData) -> types.SurfaceData:
+        return surface_layer.data
+
+    viewer.window.add_dock_widget(add_data)
+    add_data()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[1], Surface)
+    npt.assert_array_equal(viewer.layers[1].scale, (1, 2, 2))
+    npt.assert_array_equal(viewer.layers[1].translate, (3, 4, 4))
+    assert viewer.layers[1].units == viewer.layers[0].units
+
+
+def test_magicgui_add_data_inheritance_two_layer(make_napari_viewer):
+    """This test validates if the scale and translate are inherited if more than
+    one source layer is passed to function when adding a new layer
+    with magicgui if function requests, a LayerData type.
+    """
+    rng = np.random.default_rng(0)
+    viewer = make_napari_viewer()
+    viewer.add_image(rng.random((10, 10)), scale=(1, 2), translate=(3, 4))
+    viewer.add_labels(
+        (rng.random((10, 10)) > 0.5).astype('uint8'),
+        scale=(1, 2),
+        translate=(3, 4),
+    )
+
+    @magicgui
+    def add_data(
+        data1: types.ImageData, data2: types.LabelsData
+    ) -> types.LabelsData:
+        return (data1 * data2).astype('uint8')
+
+    viewer.window.add_dock_widget(add_data)
+    add_data()
+    assert len(viewer.layers) == 3
+    assert isinstance(viewer.layers[2], Labels)
+    npt.assert_array_equal(viewer.layers[2].scale, (1, 2))
+    npt.assert_array_equal(viewer.layers[2].translate, (3, 4))
+
+
+def test_magicgui_add_data_inheritance_two_layer_inconsistent(
+    make_napari_viewer, monkeypatch
+):
+    """This test validates the scale and translate are not inherited from the
+    previous layers with inconsistend metadata when adding a new layer
+    with magicgui if function requests,
+    a LayerData type.
+    """
+    rng = np.random.default_rng(0)
+    viewer = make_napari_viewer()
+    viewer.add_image(rng.random((10, 10)), scale=(1, 2), translate=(3, 4))
+    viewer.add_labels(
+        (rng.random((10, 10)) > 0.5).astype('uint8'),
+        scale=(2, 2),
+        translate=(3, 4),
+    )
+
+    @magicgui
+    def add_data(
+        data1: types.ImageData, data2: types.LabelsData
+    ) -> types.LabelsData:
+        return (data1 * data2).astype('uint8')
+
+    viewer.window.add_dock_widget(add_data)
+    mock = Mock()
+    monkeypatch.setattr(
+        'napari.utils.notifications.notification_manager.dispatch', mock
+    )
+    add_data()
+    mock.assert_called_once()
+    assert mock.call_args[0][0].message.startswith('Cannot inherit spatial')
+    assert len(viewer.layers) == 3
+    assert isinstance(viewer.layers[2], Labels)
+    npt.assert_array_equal(viewer.layers[2].scale, (1, 1))
+    npt.assert_array_equal(viewer.layers[2].translate, (0, 0))
+
+
+def test_magicgui_add_layer_inheritance(make_napari_viewer):
+    """This test validates if the scale and translate are inherited from the
+    previous layer when adding a new layer with magicgui if function requests,
+    a Layer type.
+    It also checks if the presence of additional combo box in the
+    function does not affect getting the data from the previous layer.
+    """
+    rng = np.random.default_rng(0)
+    viewer = make_napari_viewer()
+    viewer.add_image(rng.random((10, 10)), scale=(2, 2), translate=(1, 1))
+
+    class SampleEnum(Enum):
+        A = 'A'
+        B = 'B'
+
+    @magicgui
+    def add_data(
+        data: Image, factor: float = 0.5, combo: SampleEnum = SampleEnum.A
+    ) -> types.LabelsData:
+        return (data.data > factor).astype(
+            'uint8' if combo == SampleEnum.A else 'uint16'
+        )
+
+    viewer.window.add_dock_widget(add_data)
+    add_data()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[1], Labels)
+    npt.assert_array_equal(viewer.layers[1].scale, (2, 2))
+    npt.assert_array_equal(viewer.layers[1].translate, (1, 1))
+
+
+def test_magicgui_add_data_inheritance_upper_dim(make_napari_viewer):
+    """In the current implementation, layer with dimensionality lower than produced data are ignored"""
+    rng = np.random.default_rng(0)
+    viewer = make_napari_viewer()
+    viewer.add_image(rng.random((10, 10)), scale=(2, 2), translate=(1, 1))
+
+    @magicgui
+    def add_data(data: types.ImageData) -> types.LabelsData:
+        return np.stack([(data > 0.5), (data > 0.4)]).astype('uint8')
+
+    viewer.window.add_dock_widget(add_data)
+    add_data()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[1], Labels)
+    npt.assert_array_equal(viewer.layers[1].scale, (1, 1, 1))
+    npt.assert_array_equal(viewer.layers[1].translate, (0, 0, 0))
+
+
+def test_magicgui_add_data_inheritance_less_dim(make_napari_viewer):
+    viewer = make_napari_viewer()
+    viewer.add_image(
+        np.random.rand(4, 10, 10), scale=(1, 2, 2), translate=(2, 1, 1)
+    )
+
+    @magicgui
+    def add_data(data: types.ImageData) -> types.LabelsData:
+        return (data[0] > 0.5).astype('uint8')
+
+    viewer.window.add_dock_widget(add_data)
+    add_data()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[1], Labels)
+    npt.assert_array_equal(viewer.layers[1].scale, (2, 2))
+    npt.assert_array_equal(viewer.layers[1].translate, (1, 1))
 
 
 def test_add_layer_data_to_viewer_optional(make_napari_viewer):


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/6986

# References and relevant issues

This is part of the implementation of units in napari 

# Description

As we support functional plugins that get and return only layer data, we should inherit spatial properties from source layers. 

In the current implementation, layer with dimensionality lower than produced data are ignored. 

If spatial information of all source data of dimensionality at least the same as result data is consistent, the new created layer has the same spatial informat...